### PR TITLE
Making the terminal option more visible and removing home buttom redundancy from all pages 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,12 @@ A premium, minimalist developer portfolio built with **Next.js 15**, **TypeScrip
 
 4. Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+## 🔐 Admin Access
+
+The blog section includes a secret administrative mode to create and delete posts.
+- **Trigger**: Click the Copyright text in the footer **3 times** while on the `/blog` page.
+- **Passcode**: Enter the preset passcode to enable Write/Delete permissions.
+
+---
+
 Built with intent by [Akshat Srivastava](https://github.com/akshatsri3).

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -14,35 +14,6 @@ export default function AboutPage() {
 
       <main className="flex-grow container mx-auto px-6 pt-6 md:pt-8 pb-12 md:pb-24">
         <div className="max-w-4xl mx-auto">
-          {/* Back Button */}
-          <motion.div
-            initial={{ opacity: 0, x: -20 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ duration: 0.5 }}
-            className="mb-8"
-          >
-            <Link
-              href="/"
-              aria-label="Back to home"
-              className="group inline-flex items-center justify-center w-9 h-9 rounded-full text-muted-foreground hover:text-primary hover:bg-white/5 transition-all duration-200"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.75"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="transition-transform duration-200 group-hover:-translate-y-0.5"
-              >
-                <path d="M3 9.5L12 3l9 6.5V20a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V9.5z" />
-                <path d="M9 21V12h6v9" />
-              </svg>
-            </Link>
-          </motion.div>
 
           {/* Hero Section / Profile Image */}
           <motion.div

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -55,27 +55,6 @@ export default function BlogPage() {
         <div className="max-w-4xl mx-auto">
           <div className="flex justify-between items-end mb-12">
             <div>
-              <Link
-                href="/"
-                aria-label="Back to home"
-                className="group inline-flex items-center justify-center w-9 h-9 rounded-full text-muted-foreground hover:text-primary hover:bg-white/5 transition-all duration-200 mb-4"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="18"
-                  height="18"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="transition-transform duration-200 group-hover:-translate-y-0.5"
-                >
-                  <path d="M3 9.5L12 3l9 6.5V20a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V9.5z" />
-                  <path d="M9 21V12h6v9" />
-                </svg>
-              </Link>
               <h1
                 className="text-6xl md:text-8xl font-normal tracking-normal text-gradient py-4"
                 style={{ fontFamily: "var(--font-great-vibes), cursive" }}

--- a/src/app/clicks/page.tsx
+++ b/src/app/clicks/page.tsx
@@ -49,35 +49,6 @@ export default function ClicksPage() {
 
       <main className="flex-grow container mx-auto px-6 pt-6 md:pt-8 pb-12 md:pb-24">
         <div className="max-w-6xl mx-auto">
-          {/* Back Button */}
-          <motion.div
-            initial={{ opacity: 0, x: -20 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ duration: 0.5 }}
-            className="mb-8"
-          >
-            <Link
-              href="/"
-              aria-label="Back to home"
-              className="group inline-flex items-center justify-center w-9 h-9 rounded-full text-muted-foreground hover:text-primary hover:bg-white/5 transition-all duration-200"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.75"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="transition-transform duration-200 group-hover:-translate-y-0.5"
-              >
-                <path d="M3 9.5L12 3l9 6.5V20a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V9.5z" />
-                <path d="M9 21V12h6v9" />
-              </svg>
-            </Link>
-          </motion.div>
 
           {/* Header */}
           <div className="text-center mb-0 md:mb-12">

--- a/src/components/terminal-branding.tsx
+++ b/src/components/terminal-branding.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+interface TerminalBrandingProps {
+  onClick?: () => void;
+  className?: string;
+}
+
+export const TerminalBranding = ({ onClick, className }: TerminalBrandingProps) => {
+  const [isHovered, setIsHovered] = useState(false);
+  const [showNudge, setShowNudge] = useState(false);
+
+  useEffect(() => {
+    const visited = localStorage.getItem("hasVisitedTerminalBranding");
+    if (!visited) {
+      const timer = setTimeout(() => {
+        setShowNudge(true);
+      }, 2500);
+      return () => clearTimeout(timer);
+    }
+  }, []);
+
+  const handleAction = () => {
+    if (showNudge) {
+      setShowNudge(false);
+      localStorage.setItem("hasVisitedTerminalBranding", "true");
+    }
+    onClick?.();
+  };
+
+  // SVG for the terminal block cursor
+  const terminalCursor = `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="20" viewBox="0 0 12 20" fill="none"><rect x="0" y="2" width="10" height="16" fill="%23a78bfa" fill-opacity="0.9" /></svg>'), auto`;
+
+  return (
+    <div className="relative inline-block">
+      <button
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        onClick={handleAction}
+        style={{ cursor: isHovered ? terminalCursor : "pointer" }}
+        className={cn(
+          "group relative flex items-center font-mono text-xl font-bold tracking-tighter transition-all duration-300",
+          "text-white hover:text-violet-400 focus:outline-none",
+          className
+        )}
+        aria-label="Open terminal"
+      >
+        {/* The Animated Prompt */}
+        <motion.span
+          initial={false}
+          animate={{ 
+            opacity: isHovered || showNudge ? 1 : 0.6,
+            x: isHovered ? 0 : -2,
+            scale: isHovered ? 1.1 : 1
+          }}
+          transition={{ duration: 0.2 }}
+          className="mr-1.5 text-violet-400 inline-block font-mono"
+        >
+          &gt;
+        </motion.span>
+
+        {/* The Text with Flicker effect on hover */}
+        <span className="relative inline-block">
+          Akshat
+          {isHovered && (
+            <motion.span
+              animate={{ 
+                opacity: [0, 0.4, 0.2, 0.5, 0.3],
+                scale: [1, 1.02, 0.98, 1.01, 1]
+              }}
+              transition={{ 
+                duration: 0.15, 
+                repeat: Infinity,
+                repeatType: "reverse" 
+              }}
+              className="absolute inset-0 bg-violet-400/20 blur-md -z-10 rounded-full"
+            />
+          )}
+        </span>
+
+        {/* Pulse Glow for Nudge */}
+        {showNudge && (
+          <motion.div
+            layoutId="nudge-glow"
+            className="absolute -inset-4 rounded-full bg-violet-400/15 blur-xl -z-20"
+            animate={{ 
+              opacity: [0.2, 0.5, 0.2],
+              scale: [0.8, 1.1, 0.8]
+            }}
+            transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
+          />
+        )}
+      </button>
+
+      {/* Tooltip */}
+      <AnimatePresence>
+        {showNudge && (
+          <motion.div
+            initial={{ opacity: 0, y: 12, scale: 0.9 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 8, scale: 0.9 }}
+            transition={{ type: "spring", damping: 15, stiffness: 300 }}
+            className="absolute -bottom-11 left-0 whitespace-nowrap rounded-lg border border-white/10 bg-black/80 px-3 py-1.5 font-mono text-[11px] text-neutral-300 backdrop-blur-md shadow-xl z-[60]"
+          >
+            <span className="text-violet-400 animate-pulse mr-1">&gt;</span> try clicking
+            <div className="absolute -top-1 left-4 w-2 h-2 bg-black/80 border-t border-l border-white/10 rotate-45" />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/src/components/ui/animated-testimonials.tsx
+++ b/src/components/ui/animated-testimonials.tsx
@@ -20,6 +20,7 @@ export const AnimatedTestimonials = ({
   autoplay?: boolean;
 }) => {
   const [active, setActive] = useState(0);
+  const [rotations, setRotations] = useState<number[]>([]);
 
   const handleNext = () => {
     setActive((prev) => (prev + 1) % testimonials.length);
@@ -38,11 +39,14 @@ export const AnimatedTestimonials = ({
       const interval = setInterval(handleNext, 5000);
       return () => clearInterval(interval);
     }
-  }, [autoplay]);
+  }, [autoplay, testimonials.length]);
 
-  const randomRotateY = () => {
-    return Math.floor(Math.random() * 21) - 10;
-  };
+  useEffect(() => {
+    setRotations(testimonials.map(() => Math.floor(Math.random() * 21) - 10));
+  }, [testimonials]);
+
+  const getRotation = (index: number) => rotations[index] || 0;
+
   return (
     <div className="mx-auto max-w-sm px-4 py-20 font-sans antialiased md:max-w-4xl md:px-8 lg:px-12">
       <div className="relative grid grid-cols-1 gap-20 md:grid-cols-2">
@@ -56,13 +60,13 @@ export const AnimatedTestimonials = ({
                     opacity: 0,
                     scale: 0.9,
                     z: -100,
-                    rotate: randomRotateY(),
+                    rotate: getRotation(index),
                   }}
                   animate={{
                     opacity: isActive(index) ? 1 : 0.7,
                     scale: isActive(index) ? 1 : 0.95,
                     z: isActive(index) ? 0 : -100,
-                    rotate: isActive(index) ? 0 : randomRotateY(),
+                    rotate: isActive(index) ? 0 : getRotation(index),
                     zIndex: isActive(index)
                       ? 40
                       : testimonials.length + 2 - index,
@@ -72,7 +76,7 @@ export const AnimatedTestimonials = ({
                     opacity: 0,
                     scale: 0.9,
                     z: 100,
-                    rotate: randomRotateY(),
+                    rotate: getRotation(index),
                   }}
                   transition={{
                     duration: 0.4,

--- a/src/components/ui/resizable-navbar.tsx
+++ b/src/components/ui/resizable-navbar.tsx
@@ -7,6 +7,9 @@ import {
 } from "framer-motion";
 
 import React, { useState } from "react";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import { TerminalBranding } from "@/components/terminal-branding";
 
 
 interface NavbarProps {
@@ -168,25 +171,42 @@ export const MobileNavToggle = ({
   );
 };
 
+
 export const NavbarLogo = ({ onLogoClick }: { onLogoClick?: () => void }) => {
-  if (onLogoClick) {
+  const pathname = usePathname();
+  const isHomePage = pathname === "/";
+
+  if (!isHomePage) {
     return (
-      <button
-        onClick={onLogoClick}
-        className="relative z-20 flex items-center space-x-2 text-xl font-bold tracking-tighter text-white hover:text-primary transition-colors"
-        aria-label="Open terminal"
+      <Link
+        href="/"
+        aria-label="Back to home"
+        className="group relative z-20 inline-flex items-center justify-center w-9 h-9 rounded-full text-muted-foreground hover:text-white hover:bg-white/5 transition-all duration-200"
       >
-        Akshat
-      </button>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="transition-transform duration-200 group-hover:-translate-y-0.5"
+        >
+          <path d="M3 9.5L12 3l9 6.5V20a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V9.5z" />
+          <path d="M9 21V12h6v9" />
+        </svg>
+      </Link>
     );
   }
+
   return (
-    <a
-      href="/"
-      className="relative z-20 flex items-center space-x-2 text-xl font-bold tracking-tighter text-white hover:text-primary transition-colors"
-    >
-      Akshat
-    </a>
+    <TerminalBranding 
+      onClick={onLogoClick} 
+      className="relative z-20"
+    />
   );
 };
 


### PR DESCRIPTION
Add a new TerminalBranding component (interactive terminal-style logo with nudge/pulse and localStorage) and integrate it into the navbar. Replace multiple per-page back-button implementations by using a home-link/icon for non-home routes and the TerminalBranding for the home logo. Improve AnimatedTestimonials by precomputing per-testimonial random rotations (stable across renders) and adjust autoplay effect dependencies. Also add a README note documenting a secret admin mode for the blog. Files: adds src/components/terminal-branding.tsx, updates resizable-navbar, animated-testimonials, about/blog/clicks pages (removed duplicated back button markup), and README.md.